### PR TITLE
Arbitrary block info

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject link.szabo.mauricio/duck-repled "0.1.0"
+(defproject link.szabo.mauricio/duck-repled "0.1.1"
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/duck_repled/definition_resolvers.cljc
+++ b/src/duck_repled/definition_resolvers.cljc
@@ -67,7 +67,7 @@
 (connect/defresolver clojure-filename [{:keys [:repl/evaluator :var/meta
                                                :repl/kind :repl/clj]}]
   {::pco/input [:repl/evaluator :var/meta :repl/kind (pco/? :repl/clj)]
-   ::pco/output [:definition/filename :definition/file-contents
+   ::pco/output [:definition/filename
                  {:definition/contents [:text/contents :text/range]}]}
 
   (when-let [repl (case kind
@@ -86,7 +86,6 @@
         (p/let [{:keys [result]} (read-jar repl filename)
                 pos [(-> meta (:line 1) dec) (-> meta (:column 1) dec)]]
           {:definition/filename filename
-           :definition/file-contents result
            :definition/contents {:text/contents result
                                  :text/range [pos pos]}})
         {:definition/filename filename}))))

--- a/src/duck_repled/definition_resolvers.cljc
+++ b/src/duck_repled/definition_resolvers.cljc
@@ -67,7 +67,8 @@
 (connect/defresolver clojure-filename [{:keys [:repl/evaluator :var/meta
                                                :repl/kind :repl/clj]}]
   {::pco/input [:repl/evaluator :var/meta :repl/kind (pco/? :repl/clj)]
-   ::pco/output [:definition/filename :definition/file-contents]}
+   ::pco/output [:definition/filename :definition/file-contents
+                 {:definition/contents [:text/contents :text/range]}]}
 
   (when-let [repl (case kind
                    :clj evaluator
@@ -82,9 +83,12 @@
             {:keys [result]} (repl/eval repl code)
             filename (norm-result result)]
       (if (re-find #"\.jar!/" filename)
-        (p/let [{:keys [result]} (read-jar repl filename)]
+        (p/let [{:keys [result]} (read-jar repl filename)
+                pos [(-> meta (:line 1) dec) (-> meta (:column 1) dec)]]
           {:definition/filename filename
-           :definition/file-contents result})
+           :definition/file-contents result
+           :definition/contents {:text/contents result
+                                 :text/range [pos pos]}})
         {:definition/filename filename}))))
 
 (connect/defresolver file-from-clr [{:keys [:repl/evaluator :var/meta :repl/kind]}]

--- a/src/duck_repled/editor_resolvers.cljc
+++ b/src/duck_repled/editor_resolvers.cljc
@@ -12,14 +12,11 @@
   seed)
 
 (connect/defresolver separate-data [{editor-data :editor/data}]
-  {::pco/output [:editor/contents :editor/filename :editor/range
-                 {:editor/text [:text/contents :text/range]}]}
+  {::pco/output [:editor/filename {:editor/text [:text/contents :text/range]}]}
 
   ; (when-let [editor-data (-> env :seed :editor/data)]
   (let [file (:filename editor-data)]
-    (cond-> {:editor/contents (:contents editor-data)
-             :editor/range (:range editor-data)
-             :editor/text {:text/contents (:contents editor-data)
+    (cond-> {:editor/text {:text/contents (:contents editor-data)
                            :text/range (:range editor-data)}}
             file (assoc :editor/filename file))))
 

--- a/src/duck_repled/editor_resolvers.cljc
+++ b/src/duck_repled/editor_resolvers.cljc
@@ -12,12 +12,12 @@
   seed)
 
 (connect/defresolver separate-data [{editor-data :editor/data}]
-  {::pco/output [:editor/filename {:editor/text [:text/contents :text/range]}]}
+  {::pco/output [:editor/filename {:editor/contents [:text/contents :text/range]}]}
 
   ; (when-let [editor-data (-> env :seed :editor/data)]
   (let [file (:filename editor-data)]
-    (cond-> {:editor/text {:text/contents (:contents editor-data)
-                           :text/range (:range editor-data)}}
+    (cond-> {:editor/contents {:text/contents (:contents editor-data)
+                               :text/range (:range editor-data)}}
             file (assoc :editor/filename file))))
 
 (connect/defresolver namespace-from-text [{:text/keys [top-blocks range]}]
@@ -52,10 +52,10 @@
     {:text/selection (cond-> {:text/contents text :text/range range}
                              ns (assoc :text/ns ns))}))
 
-(connect/defresolver default-text-elements [{:keys [editor/text]}]
+(connect/defresolver default-text-elements [{:keys [editor/contents]}]
   {::pco/priority -10}
-  {:text/contents (:text/contents text)
-   :text/range (:text/range text)})
+  {:text/contents (:text/contents contents)
+   :text/range (:text/range contents)})
 
 (connect/defresolver resolver-for-ns [inputs]
   {::pco/input [(pco/? :text/ns)
@@ -63,7 +63,7 @@
    ::pco/output [:repl/namespace]}
 
   (let [contents (or (-> inputs :text/ns :text/contents)
-                     (-> inputs :editor/text :text/ns :text/contents))
+                     (-> inputs :editor/contents :text/ns :text/contents))
         kind (:repl/kind inputs)]
     (cond
       contents {:repl/namespace (symbol contents)}

--- a/src/duck_repled/editor_resolvers.cljc
+++ b/src/duck_repled/editor_resolvers.cljc
@@ -3,7 +3,8 @@
             [duck-repled.schemas :as schemas]
             [duck-repled.connect :as connect]
             [com.wsscode.pathom3.connect.operation :as pco]
-            [duck-repled.editor-helpers :as editor-helpers]))
+            [duck-repled.editor-helpers :as editor-helpers]
+            ["fs" :refer [readFileSync]]))
 
 (connect/defresolver seed-data [{:keys [seed]} _]
   {::pco/output (->> schemas/registry keys (remove #{:map}) vec)
@@ -11,102 +12,95 @@
   seed)
 
 (connect/defresolver separate-data [{editor-data :editor/data}]
-  {::pco/output [:editor/contents :editor/filename :editor/range]}
+  {::pco/output [:editor/contents :editor/filename :editor/range
+                 {:editor/text [:text/contents :text/range]}]}
 
   ; (when-let [editor-data (-> env :seed :editor/data)]
   (let [file (:filename editor-data)]
     (cond-> {:editor/contents (:contents editor-data)
-             :editor/range (:range editor-data)}
+             :editor/range (:range editor-data)
+             :editor/text {:text/contents (:contents editor-data)
+                           :text/range (:range editor-data)}}
             file (assoc :editor/filename file))))
 
-(connect/defresolver top-blocks [{:editor/keys [contents]}]
-  {:editor/top-blocks (editor-helpers/top-blocks contents)})
+; (connect/defresolver top-blocks [{:editor/keys [contents]}]
+;   {:editor/top-blocks (editor-helpers/top-blocks contents)})
 
-(connect/defresolver namespace-from-editor-data [{:editor/keys [top-blocks range]
-                                                  :as inputs}]
-  {::pco/input [:editor/top-blocks :editor/range]
-   ::pco/output [{:editor/ns [:text/contents :text/range]}]}
+; (connect/defresolver namespace-from-editor-data [{:editor/keys [top-blocks range]
+;                                                   :as inputs}]
+;   {::pco/input [:editor/top-blocks :editor/range]
+;    ::pco/output [{:editor/ns [:text/contents :text/range]}]}
+;
+;   (when-let [[range ns] (editor-helpers/ns-range-for top-blocks (first range))]
+;     {:editor/ns {:text/contents (str ns) :text/range range}}))
+
+(connect/defresolver namespace-from-text [{:text/keys [top-blocks range]}]
+  {::pco/output [{:text/ns [:text/contents :text/range :text/ns]}]}
 
   (when-let [[range ns] (editor-helpers/ns-range-for top-blocks (first range))]
-    {:editor/ns {:text/contents (str ns) :text/range range}}))
+    {:text/ns {:text/contents (str ns) :text/range range}}))
 
-(connect/defresolver current-top-block [{:editor/keys [top-blocks range]
-                                         :as inputs}]
-  {::pco/input [:editor/top-blocks :editor/range
-                (pco/? :repl/evaluator) (pco/? {:editor/ns [:text/contents]})]
-   ::pco/output [{:editor/top-block [:text/contents :text/range :repl/evaluator]}]}
+; (connect/defresolver current-top-block [{:editor/keys [top-blocks range]}]
+;   {::pco/output [{:editor/top-block [:text/contents :text/range]}]}
+;   (when-let [[range text] (editor-helpers/top-block-for top-blocks (first range))]
+;     {:editor/top-block {:text/contents text :text/range range}}))
+
+(connect/defresolver contents-top-blocks [{:text/keys [contents]}]
+  {:text/top-blocks (editor-helpers/top-blocks contents)})
+
+(connect/defresolver contents-top-block [{:text/keys [top-blocks range ns]}]
+  {::pco/input [:text/top-blocks :text/range (pco/? :text/ns)]
+   ::pco/output [{:text/top-block [:text/contents :text/range :text/ns]}]}
 
   (when-let [[range text] (editor-helpers/top-block-for top-blocks (first range))]
-    {:editor/top-block {:text/contents text :text/range range}}))
+    {:text/top-block (cond-> {:text/contents text :text/range range}
+                             ns (assoc :text/ns ns))}))
 
-(connect/defresolver current-block [{:editor/keys [contents range]
-                                     :as inputs}]
-  {::pco/input [:editor/contents :editor/range
-                (pco/? :repl/evaluator) (pco/? {:editor/ns [:text/contents]})]
-   ::pco/output [{:editor/block [:text/contents :text/range :repl/evaluator]}]}
+; (connect/defresolver editor-block [{:editor/keys [contents range]}]
+;   {::pco/output [{:editor/block [:text/contents :text/range]}]}
+;   (when-let [[range text] (editor-helpers/block-for contents (first range))]
+;     {:editor/block {:text/contents text :text/range range}}))
 
+(connect/defresolver text-block [{:text/keys [contents range ns]}]
+  {::pco/input [:text/contents :text/range (pco/? :text/ns)]
+   ::pco/output [{:text/block [:text/contents :text/range :text/ns]}]}
   (when-let [[range text] (editor-helpers/block-for contents (first range))]
-    {:editor/block {:text/contents text :text/range range}}))
+    {:text/block (cond-> {:text/contents text :text/range range}
+                         ns (assoc :text/ns ns))}))
 
-(connect/defresolver current-selection [{:editor/keys [contents range]
-                                         :as inputs}]
-  {::pco/input [:editor/contents :editor/range
-                (pco/? :repl/evaluator) (pco/? {:editor/ns [:text/contents]})]
-   ::pco/output [{:editor/selection [:text/contents :text/range :repl/evaluator]}]}
+; (connect/defresolver current-selection [{:editor/keys [contents range]}]
+;   {::pco/input [:editor/contents :editor/range]
+;    ::pco/output [{:editor/selection [:text/contents :text/range]}]}
+;
+;   (when-let [text (editor-helpers/text-in-range contents range)]
+;     {:editor/selection {:text/contents text :text/range range}}))
+
+(connect/defresolver text-selection [{:text/keys [contents range ns]}]
+  {::pco/input [:text/contents :text/range (pco/? :text/ns)]
+   ::pco/output [{:text/selection [:text/contents :text/range :text/ns]}]}
 
   (when-let [text (editor-helpers/text-in-range contents range)]
-    {:editor/selection {:text/contents text :text/range range}}))
+    {:text/selection (cond-> {:text/contents text :text/range range}
+                             ns (assoc :text/ns ns))}))
 
-; (connect/defresolver default-namespaces [env {:keys [repl/kind]}]
-;   {:repl/namespace (if (= :cljs kind) 'cljs.user 'user)})
-;
-; (connect/defresolver namespace-from-editor [inputs]
-;   {::pco/input [{:editor/ns [:text/contents]}]
-;    ::pco/output [:repl/namespace] ::pco/priority 1}
-;   {:repl/namespace (-> inputs :editor/ns :text/contents symbol)})
+(connect/defresolver default-text-elements [{:keys [editor/text]}]
+  {::pco/priority -10}
+  {:text/contents (:text/contents text)
+   :text/range (:text/range text)})
 
 (connect/defresolver resolver-for-ns [inputs]
-  {::pco/input [(pco/? {:editor/ns [:text/contents]})
+  {::pco/input [(pco/? :text/ns)
                 (pco/? :repl/kind)]
    ::pco/output [:repl/namespace]}
 
-  (let [contents (-> inputs :editor/ns :text/contents)
+  (let [contents (or (-> inputs :text/ns :text/contents)
+                     (-> inputs :editor/text :text/ns :text/contents))
         kind (:repl/kind inputs)]
     (cond
-      contents {:repl/namespace (-> inputs :editor/ns :text/contents symbol)}
+      contents {:repl/namespace (symbol contents)}
       (nil? kind) nil
       (= :cljs kind) {:repl/namespace 'cljs.user}
       :not-cljs {:repl/namespace 'user})))
-
-; (connect/defresolver not-clj-repl-kind [{:config/keys [repl-kind]}]
-;   {::pco/output [:repl/kind] ::pco/priority 2}
-;
-;   (when (not= :clj repl-kind)
-;     {:repl/kind repl-kind}))
-;
-; (connect/defresolver repl-kind-from-config [{:config/keys [eval-as]}]
-;   {::pco/output [:repl/kind] ::pco/priority 1}
-;
-;   (case eval-as
-;     :clj {:repl/kind :clj}
-;     :cljs {:repl/kind :cljs}
-;     nil))
-;     ; ::pco/unknown-value))
-;
-; (connect/defresolver repl-kind-from-config-and-file
-;   [{:keys [config/eval-as editor/filename]}]
-;   {::pco/output [:repl/kind]}
-;
-;   (prn :CHECKING-PRIORITY-0)
-;   (let [cljs-file? (str/ends-with? filename ".cljs")
-;         cljc-file? (or (str/ends-with? filename ".cljc")
-;                        (str/ends-with? filename ".cljx"))]
-;     (case eval-as
-;       :prefer-clj {:repl/kind (if cljs-file? :cljs :clj)}
-;       :prefer-cljs {:repl/kind (if (and (not cljs-file?) (not cljc-file?))
-;                                  :clj
-;                                  :cljs)}
-;       nil)))
 
 (connect/defresolver resolve-repl-kind
   [{:keys [config/repl-kind config/eval-as editor/filename]}]
@@ -132,13 +126,21 @@
                                    :cljs)}
         nil))))
 
-(connect/defresolver var-from-editor
-  [{:editor/keys [contents range]}]
-  {::pco/output [{:editor/current-var [:text/contents :text/range]}]}
+; (connect/defresolver var-from-editor
+;   [{:editor/keys [contents range]}]
+;   {::pco/output [{:editor/current-var [:text/contents :text/range]}]}
+;
+;   (when-let [[range curr-var] (editor-helpers/current-var contents (first range))]
+;     {:editor/current-var {:text/contents curr-var
+;                           :text/range range}}))
+
+(connect/defresolver var-from-text [{:text/keys [contents range ns]}]
+  {::pco/input [:text/contents :text/range (pco/? :text/ns)]
+   ::pco/output [{:text/current-var [:text/contents :text/range :text/ns]}]}
 
   (when-let [[range curr-var] (editor-helpers/current-var contents (first range))]
-    {:editor/current-var {:text/contents curr-var
-                          :text/range range}}))
+    {:text/current-var (cond-> {:text/contents curr-var :text/range range}
+                               ns (assoc :text/ns ns))}))
 
 ; (pco/defresolver all-namespaces
 ;   [env {:keys [repl/clj]}]
@@ -259,11 +261,19 @@
 ;                    (.-test res) (assoc :test (.-test res)))})))
 ;
 
-(def resolvers [seed-data separate-data top-blocks
-                namespace-from-editor-data
+(def resolvers [seed-data separate-data
+                ;top-blocks
+                ;namespace-from-editor-data
                 resolver-for-ns
                 ; default-namespaces namespace-from-editor
-                var-from-editor current-top-block current-block current-selection
+                ;var-from-editor current-top-block current-selection
+
+                ; BLOCKS
+                ;editor-block
+                text-block
+                contents-top-blocks contents-top-block
+                var-from-text text-selection namespace-from-text
 
                 ; repl-kind-from-config not-clj-repl-kind repl-kind-from-config-and-file
-                resolve-repl-kind])
+                resolve-repl-kind
+                default-text-elements])

--- a/src/duck_repled/repl_resolvers.cljc
+++ b/src/duck_repled/repl_resolvers.cljc
@@ -38,19 +38,23 @@
       {:repl/error result}
       {:repl/result result})))
 
+(defn- extract-right-var [current-var contents]
+  (let [contents (or (:text/contents current-var) contents)
+        [_ var] (helpers/current-var (str contents) [0 0])]
+    (when (and var (= var contents))
+      contents)))
+
 (connect/defresolver fqn-var
   [{:keys [repl/namespace text/current-var text/contents repl/evaluator]}]
   {::pco/input [:repl/namespace :repl/evaluator
                 (pco/? :text/current-var) (pco/? :text/contents)]
    ::pco/output [:var/fqn]}
 
-  (let [contents (or (:text/contents current-var) contents)
-        [_ var] (helpers/current-var (str contents) [0 0])]
-    (when (and var (= var contents))
-      (p/let [{:keys [result]} (repl/eval evaluator
-                                          (str "`" contents)
-                                          {:namespace (str namespace)})]
-        {:var/fqn result}))))
+  (when-let [contents (extract-right-var current-var contents)]
+    (p/let [{:keys [result]} (repl/eval evaluator
+                                        (str "`" contents)
+                                        {:namespace (str namespace)})]
+      {:var/fqn result})))
 
 (defn- eval-for-meta [evaluator var-name namespace]
   (p/let [{:keys [result]} (repl/eval evaluator
@@ -62,18 +66,22 @@
     (when result {:var/meta result})))
 
 (connect/defresolver meta-for-var
-  [{:keys [repl/namespace editor/current-var repl/evaluator config/repl-kind]}]
-  {::pco/input [:repl/namespace :editor/current-var :repl/evaluator
+  [{:keys [repl/namespace repl/evaluator config/repl-kind
+           text/current-var text/contents]}]
+  {::pco/input [:repl/namespace :repl/evaluator
+                (pco/? :text/current-var) (pco/? :text/contents)
                 (pco/? :config/repl-kind)]
    ::pco/output [:var/meta]
    ::pco/priority 1}
-  (p/let [meta (eval-for-meta evaluator (:text/contents current-var) namespace)]
-    (if (= :clje repl-kind)
-      (walk/postwalk #(cond-> %
-                              (and (tagged-literal? %) (-> % .-tag (= 'erl)))
-                              .-form)
-                     meta)
-      meta)))
+
+  (when-let [contents (extract-right-var current-var contents)]
+    (p/let [meta (eval-for-meta evaluator contents namespace)]
+      (if (= :clje repl-kind)
+        (walk/postwalk #(cond-> %
+                                (and (tagged-literal? %) (-> % .-tag (= 'erl)))
+                                .-form)
+                       meta)
+        meta))))
 
 (connect/defresolver meta-for-clj-var
   [{:keys [var/fqn repl/clj repl/kind]}]

--- a/src/duck_repled/schemas.cljc
+++ b/src/duck_repled/schemas.cljc
@@ -30,10 +30,16 @@
    :editor/top-block (m/schema contents)
    :editor/block (m/schema contents)
    :editor/selection (m/schema contents)
-   ; :editor/current-var-range (m/schema range)
+   :editor/text (m/schema contents)
 
    :text/contents (m/schema string?)
    :text/range (m/schema range)
+   :text/top-blocks (m/schema top-blocks)
+   :text/current-var (m/schema contents)
+   :text/ns (m/schema contents)
+   :text/top-block (m/schema contents)
+   :text/block (m/schema contents)
+   :text/selection (m/schema contents)
 
    :file/path (m/schema [:vector string?])
    :file/filename (m/schema string?)

--- a/src/duck_repled/schemas.cljc
+++ b/src/duck_repled/schemas.cljc
@@ -19,17 +19,7 @@
 
 (def registry
   {:editor/data (m/schema editor-data)
-   :editor/contents (m/schema string?)
    :editor/filename (m/schema string?)
-   :editor/range (m/schema range)
-   :editor/namespace (m/schema string?)
-   :editor/top-blocks (m/schema top-blocks)
-
-   :editor/current-var (m/schema contents)
-   :editor/ns (m/schema contents)
-   :editor/top-block (m/schema contents)
-   :editor/block (m/schema contents)
-   :editor/selection (m/schema contents)
    :editor/text (m/schema contents)
 
    :text/contents (m/schema string?)
@@ -54,6 +44,7 @@
    :definition/col (m/schema int?)
    :definition/filename (m/schema string?)
    :definition/file-contents (m/schema string?)
+   :definition/contents (m/schema contents)
 
    :ex/function-name (m/schema string?)
    :ex/filename (m/schema string?)

--- a/src/duck_repled/schemas.cljc
+++ b/src/duck_repled/schemas.cljc
@@ -20,7 +20,7 @@
 (def registry
   {:editor/data (m/schema editor-data)
    :editor/filename (m/schema string?)
-   :editor/text (m/schema contents)
+   :editor/contents (m/schema contents)
 
    :text/contents (m/schema string?)
    :text/range (m/schema range)
@@ -43,7 +43,6 @@
    :definition/row (m/schema int?)
    :definition/col (m/schema int?)
    :definition/filename (m/schema string?)
-   :definition/file-contents (m/schema string?)
    :definition/contents (m/schema contents)
 
    :ex/function-name (m/schema string?)

--- a/src/duck_repled/schemas.cljc
+++ b/src/duck_repled/schemas.cljc
@@ -9,14 +9,14 @@
 (def ^:private range [:cat [:schema pos] [:schema pos]])
 (def ^:private editor-data [:map
                             [:contents string?]
-                            [:filename {:maybe true} [:maybe string?]]
+                            [:filename {:optional true} [:maybe string?]]
                             [:range range]])
 (def ^:private range-and-content [:cat [:schema range] string?])
 (def ^:private top-blocks [:vector range-and-content])
 (def ^:private contents [:map
                          [:text/contents string?]
-                         [:text/range range]
-                         [:repl/evaluator {:optional true} any?]])
+                         [:text/range range]])
+
 (def registry
   {:editor/data (m/schema editor-data)
    :editor/contents (m/schema string?)
@@ -44,6 +44,7 @@
    :file/path (m/schema [:vector string?])
    :file/filename (m/schema string?)
    :file/exists? (m/schema boolean?)
+   :file/contents (m/schema contents)
 
    :config/repl-kind (m/schema keyword?)
    :config/eval-as (m/schema [:enum :clj :cljs :prefer-clj :prefer-cljs])

--- a/test/duck_repled/core_test.cljc
+++ b/test/duck_repled/core_test.cljc
@@ -1,6 +1,6 @@
 (ns duck-repled.core-test
   (:require [check.async :refer [check testing async-test]]
-            [clojure.test :refer [deftest run-tests]]
+            [clojure.test :refer [deftest]]
             [duck-repled.core :as core]
             [promesa.core :as p]))
 
@@ -29,7 +29,3 @@
                                      :range [[0 0] [0 0]]}}
                       [:editor/filename])
                  => {:editor/filename "lol-old.clj"}))))))
-
-#?(:cljs
-   (defn- ^:dev/after-load run []
-     (run-tests)))

--- a/test/duck_repled/core_test.cljc
+++ b/test/duck_repled/core_test.cljc
@@ -9,10 +9,10 @@
     (testing "customizing resolves"
       (testing "will add a new resolver with our code"
         (let [eql (core/gen-eql
-                   (core/add-resolver {:outputs [:editor/file] :inputs [:editor/text]}
-                                      (fn [{:editor/keys [text]}]
+                   (core/add-resolver {:outputs [:editor/file] :inputs [:editor/contents]}
+                                      (fn [{:editor/keys [contents]}]
                                         {:editor/file (str "filename for "
-                                                           (:text/contents text))})))]
+                                                           (:text/contents contents))})))]
           (check (eql {:editor/data {:contents "lol"
                                      :filename ""
                                      :range [[0 0] [0 0]]}}
@@ -22,9 +22,9 @@
       (testing "will compose original resolver, and add our customization code"
         (let [eql
               (core/gen-eql
-               (core/compose-resolver {:outputs [:editor/filename] :inputs [:editor/text]}
-                                      (fn [{:editor/keys [filename text]}]
-                                        {:editor/filename (str (:text/contents text)
+               (core/compose-resolver {:outputs [:editor/filename] :inputs [:editor/contents]}
+                                      (fn [{:editor/keys [filename contents]}]
+                                        {:editor/filename (str (:text/contents contents)
                                                                "-" filename)})))]
           (check (eql {:editor/data {:contents "lol"
                                      :filename "old.clj"

--- a/test/duck_repled/core_test.cljc
+++ b/test/duck_repled/core_test.cljc
@@ -9,9 +9,10 @@
     (testing "customizing resolves"
       (testing "will add a new resolver with our code"
         (let [eql (core/gen-eql
-                   (core/add-resolver {:outputs [:editor/file] :inputs [:editor/contents]}
-                                      (fn [{:editor/keys [contents]}]
-                                        {:editor/file (str "filename for " contents)})))]
+                   (core/add-resolver {:outputs [:editor/file] :inputs [:editor/text]}
+                                      (fn [{:editor/keys [text]}]
+                                        {:editor/file (str "filename for "
+                                                           (:text/contents text))})))]
           (check (eql {:editor/data {:contents "lol"
                                      :filename ""
                                      :range [[0 0] [0 0]]}}
@@ -21,9 +22,10 @@
       (testing "will compose original resolver, and add our customization code"
         (let [eql
               (core/gen-eql
-               (core/compose-resolver {:outputs [:editor/filename] :inputs [:editor/contents]}
-                                      (fn [{:editor/keys [filename contents]}]
-                                        {:editor/filename (str contents "-" filename)})))]
+               (core/compose-resolver {:outputs [:editor/filename] :inputs [:editor/text]}
+                                      (fn [{:editor/keys [filename text]}]
+                                        {:editor/filename (str (:text/contents text)
+                                                               "-" filename)})))]
           (check (eql {:editor/data {:contents "lol"
                                      :filename "old.clj"
                                      :range [[0 0] [0 0]]}}

--- a/test/duck_repled/definition_test.cljc
+++ b/test/duck_repled/definition_test.cljc
@@ -1,6 +1,6 @@
 (ns duck-repled.definition-test
   (:require [check.async :refer [check testing async-test]]
-            [clojure.test :refer [deftest run-tests]]
+            [clojure.test :refer [deftest]]
             [duck-repled.core :as core]
             [promesa.core :as p]
             [duck-repled.repl-helpers :as helpers]
@@ -24,10 +24,9 @@
                   :config/eval-as :prefer-clj}]
 
       (when (#{:sci} helpers/*kind*)
-        (p/do!
-         (check (eql seed [:definition/row]) => {:definition/row 1})
-         (check (eql seed [:definition/filename])
-                => {:definition/filename "test/duck_repled/tests.cljs"}))))))
+        (check (eql seed [:var/meta :definition/filename :definition/row])
+               => {:definition/filename "test/duck_repled/tests.cljs"
+                    :definition/row 1})))))
 
 (deftest ns-definition
   (when (#{:sci} helpers/*kind*)
@@ -90,7 +89,3 @@
         (check (eql seed [:definition/filename :definition/row])
                => {:definition/filename #"clojure.main.*string.clj"
                    :definition/row number?})))))
-
-#?(:cljs
-   (defn- ^:dev/after-load run []
-     (run-tests)))

--- a/test/duck_repled/definition_test.cljc
+++ b/test/duck_repled/definition_test.cljc
@@ -51,18 +51,19 @@
                     :editor/data {:contents "(ns foo)\nstr/replace"
                                   :range [[1 0] [1 0]]}
                     :config/eval-as :prefer-clj}]
-        (def seed seed)
         (p/do!
          (testing "finds JAR and unpacks in CLJ and CLJS funcions"
            (check (eql (assoc-in seed [:editor/data :filename] "file.clj")
-                       [:definition/filename :definition/file-contents])
+                       [:definition/filename :definition/contents])
                   => {:definition/filename #"clojure.*jar!/clojure/string.clj"
-                      :definition/file-contents string?})
+                      :definition/contents {:text/contents #"clojure.string"
+                                            :text/range [[74 0] [74 0]]}})
 
            (check (eql (assoc-in seed [:editor/data :filename] "file.cljs")
-                       [:definition/filename :definition/file-contents])
+                       [:definition/filename :definition/contents])
                   => {:definition/filename #"clojure.*jar!/clojure/string.cljs"
-                      :definition/file-contents string?}))
+                      :definition/contents {:text/contents #"clojure.string"
+                                            :text/range [[43 0] [43 0]]}}))
 
          (testing "getting path of stacktrace"
            (check (eql (-> seed

--- a/test/duck_repled/editor_test.cljc
+++ b/test/duck_repled/editor_test.cljc
@@ -10,17 +10,17 @@
     (check (eql {:editor/data {:contents "(+ 1 2)"
                                :filename nil
                                :range [[0 0] [0 0]]}}
-                [:editor/filename :editor/text])
-           => {:editor/text {:text/contents "(+ 1 2)"
-                             :text/range [[0 0] [0 0]]}})
+                [:editor/filename :editor/contents])
+           => {:editor/contents {:text/contents "(+ 1 2)"
+                                 :text/range [[0 0] [0 0]]}})
 
     (check (eql {:editor/data {:contents "(+ 1 2)"
                                :filename "foo.clj"
                                :range [[0 0] [0 0]]}}
-                [:editor/filename :editor/text])
+                [:editor/filename :editor/contents])
 
-           => {:editor/text {:text/contents "(+ 1 2)"
-                             :text/range [[0 0] [0 0]]}
+           => {:editor/contents {:text/contents "(+ 1 2)"
+                                 :text/range [[0 0] [0 0]]}
                :editor/filename "foo.clj"})
 
     (testing "gets block/selection/etc from `:text/*` elements"
@@ -134,39 +134,39 @@
 
 (deftest ns-from-contents
   (async-test "separates editor data into fragments" {:timeout 8000}
-    (let [seed {:editor/text
+    (let [seed {:editor/contents
                 {:text/contents
                  "\n(ns first.namespace)\n\n(+ 1 2)\n\n(ns second.ns)\n\n(+ 3 4)"}}]
       (p/do!)
       (testing "gets namespace if declaration is below current selection"
-        (check (eql (assoc-in seed [:editor/text :text/range] [[0 0] [0 0]])
+        (check (eql (assoc-in seed [:editor/contents :text/range] [[0 0] [0 0]])
                     [:text/ns])
                => {:text/ns {:text/range [[1 0] [1 19]]
                                        :text/contents "first.namespace"}}))
 
       (testing "gets namespace if declaration is above current selection"
-        (check (eql (assoc-in seed [:editor/text :text/range] [[2 0] [2 0]])
+        (check (eql (assoc-in seed [:editor/contents :text/range] [[2 0] [2 0]])
                     [:text/ns])
                => {:text/ns {:text/range [[1 0] [1 19]]
                              :text/contents "first.namespace"}})
 
-        (check (eql (assoc-in seed [:editor/text :text/range]  [[5 0] [5 0]])
+        (check (eql (assoc-in seed [:editor/contents :text/range]  [[5 0] [5 0]])
                     [:text/ns])
                => {:text/ns {:text/range [[5 0] [5 13]]
                              :text/contents "second.ns"}}))
 
       (testing "gets REPL namespace if a ns exists"
-        (check (eql (assoc-in seed [:editor/text :text/range]  [[2 0] [2 0]])
+        (check (eql (assoc-in seed [:editor/contents :text/range]  [[2 0] [2 0]])
                     [:repl/namespace])
                => {:repl/namespace 'first.namespace}))
 
       (testing "fallback to default if there's no NS in editor"
-        (check (eql {:editor/text {:text/contents "" :text/range [[2 0] [2 0]]}
+        (check (eql {:editor/contents {:text/contents "" :text/range [[2 0] [2 0]]}
                      :repl/kind :clj}
                     [:repl/namespace])
                => {:repl/namespace 'user})
 
-        (check (eql {:editor/text {:text/contents "" :text/range [[2 0] [2 0]]}
+        (check (eql {:editor/contents {:text/contents "" :text/range [[2 0] [2 0]]}
                      :repl/kind :cljs}
                     [:repl/namespace])
                => {:repl/namespace 'cljs.user})))))

--- a/test/duck_repled/editor_test.cljc
+++ b/test/duck_repled/editor_test.cljc
@@ -10,53 +10,18 @@
     (check (eql {:editor/data {:contents "(+ 1 2)"
                                :filename nil
                                :range [[0 0] [0 0]]}}
-                [:editor/contents :editor/filename :editor/range
-                 :editor/text])
+                [:editor/filename :editor/text])
            => {:editor/text {:text/contents "(+ 1 2)"
-                             :text/range [[0 0] [0 0]]}
-               :editor/contents "(+ 1 2)"
-               :editor/range [[0 0] [0 0]]})
+                             :text/range [[0 0] [0 0]]}})
 
     (check (eql {:editor/data {:contents "(+ 1 2)"
                                :filename "foo.clj"
                                :range [[0 0] [0 0]]}}
-                [:editor/contents :editor/filename :editor/range])
-           => {:editor/contents "(+ 1 2)"
-               :editor/filename "foo.clj"
-               :editor/range [[0 0] [0 0]]})
+                [:editor/filename :editor/text])
 
-    ; (testing "gets current var"
-    ;   (check (eql {:editor/data {:contents "foo bar"
-    ;                              :filename "foo.clj"
-    ;                              :range [[0 4] [0 4]]}}
-    ;               [{:editor/current-var [:text/contents :text/range]}])
-    ;          => {:editor/current-var {:text/range [[0 4] [0 6]]
-    ;                                   :text/contents "bar"}}))
-    ;
-    ; (testing "gets current top-block"
-    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-    ;                              :filename "foo.clj"
-    ;                              :range [[3 4] [3 7]]}}
-    ;               [{:editor/top-block [:text/contents :text/range]}])
-    ;          => {:editor/top-block {:text/range [[2 0] [3 7]]
-    ;                                 :text/contents "( \n ( 2 3))"}}))
-    ;
-    ;
-    ; (testing "gets current block"
-    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-    ;                              :filename "foo.clj"
-    ;                              :range [[3 4] [3 7]]}}
-    ;               [{:editor/block [:text/contents :text/range]}])
-    ;          => {:editor/block {:text/range [[3 1] [3 6]]
-    ;                             :text/contents "( 2 3)"}}))
-    ;
-    ; (testing "gets current selection"
-    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-    ;                              :filename "foo.clj"
-    ;                              :range [[2 0] [3 6]]}}
-    ;               [{:editor/selection [:text/contents :text/range]}])
-    ;          => {:editor/selection {:text/range [[2 0] [3 6]]
-    ;                                 :text/contents "( \n ( 2 3)"}}))
+           => {:editor/text {:text/contents "(+ 1 2)"
+                             :text/range [[0 0] [0 0]]}
+               :editor/filename "foo.clj"})
 
     (testing "gets block/selection/etc from `:text/*` elements"
       (check (eql {:text/contents "(ns lol)(+ 1 2)\n\n( \n ( 2 3))"
@@ -196,12 +161,12 @@
                => {:repl/namespace 'first.namespace}))
 
       (testing "fallback to default if there's no NS in editor"
-        (check (eql {:editor/contents "" :editor/range [[2 0] [2 0]]
+        (check (eql {:editor/text {:text/contents "" :text/range [[2 0] [2 0]]}
                      :repl/kind :clj}
                     [:repl/namespace])
                => {:repl/namespace 'user})
 
-        (check (eql {:editor/contents "" :editor/range [[2 0] [2 0]]
+        (check (eql {:editor/text {:text/contents "" :text/range [[2 0] [2 0]]}
                      :repl/kind :cljs}
                     [:repl/namespace])
                => {:repl/namespace 'cljs.user})))))

--- a/test/duck_repled/editor_test.cljc
+++ b/test/duck_repled/editor_test.cljc
@@ -1,7 +1,8 @@
 (ns duck-repled.editor-test
   (:require [check.async :refer [check testing async-test]]
-            [clojure.test :refer [deftest run-tests]]
-            [duck-repled.core :as core]))
+            [clojure.test :refer [deftest]]
+            [duck-repled.core :as core]
+            [promesa.core :as p]))
 
 (def eql (core/gen-eql))
 (deftest editor-data
@@ -9,8 +10,11 @@
     (check (eql {:editor/data {:contents "(+ 1 2)"
                                :filename nil
                                :range [[0 0] [0 0]]}}
-                [:editor/contents :editor/filename :editor/range])
-           => {:editor/contents "(+ 1 2)"
+                [:editor/contents :editor/filename :editor/range
+                 :editor/text])
+           => {:editor/text {:text/contents "(+ 1 2)"
+                             :text/range [[0 0] [0 0]]}
+               :editor/contents "(+ 1 2)"
                :editor/range [[0 0] [0 0]]})
 
     (check (eql {:editor/data {:contents "(+ 1 2)"
@@ -21,38 +25,94 @@
                :editor/filename "foo.clj"
                :editor/range [[0 0] [0 0]]})
 
-    (testing "gets current var"
-      (check (eql {:editor/data {:contents "foo bar"
-                                 :filename "foo.clj"
-                                 :range [[0 4] [0 4]]}}
-                  [{:editor/current-var [:text/contents :text/range]}])
-             => {:editor/current-var {:text/range [[0 4] [0 6]]
-                                      :text/contents "bar"}}))
+    ; (testing "gets current var"
+    ;   (check (eql {:editor/data {:contents "foo bar"
+    ;                              :filename "foo.clj"
+    ;                              :range [[0 4] [0 4]]}}
+    ;               [{:editor/current-var [:text/contents :text/range]}])
+    ;          => {:editor/current-var {:text/range [[0 4] [0 6]]
+    ;                                   :text/contents "bar"}}))
+    ;
+    ; (testing "gets current top-block"
+    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
+    ;                              :filename "foo.clj"
+    ;                              :range [[3 4] [3 7]]}}
+    ;               [{:editor/top-block [:text/contents :text/range]}])
+    ;          => {:editor/top-block {:text/range [[2 0] [3 7]]
+    ;                                 :text/contents "( \n ( 2 3))"}}))
+    ;
+    ;
+    ; (testing "gets current block"
+    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
+    ;                              :filename "foo.clj"
+    ;                              :range [[3 4] [3 7]]}}
+    ;               [{:editor/block [:text/contents :text/range]}])
+    ;          => {:editor/block {:text/range [[3 1] [3 6]]
+    ;                             :text/contents "( 2 3)"}}))
+    ;
+    ; (testing "gets current selection"
+    ;   (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
+    ;                              :filename "foo.clj"
+    ;                              :range [[2 0] [3 6]]}}
+    ;               [{:editor/selection [:text/contents :text/range]}])
+    ;          => {:editor/selection {:text/range [[2 0] [3 6]]
+    ;                                 :text/contents "( \n ( 2 3)"}}))
 
-    (testing "gets current top-block"
-      (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-                                 :filename "foo.clj"
-                                 :range [[3 4] [3 7]]}}
-                  [{:editor/top-block [:text/contents :text/range]}])
-             => {:editor/top-block {:text/range [[2 0] [3 7]]
-                                    :text/contents "( \n ( 2 3))"}}))
+    (testing "gets block/selection/etc from `:text/*` elements"
+      (check (eql {:text/contents "(ns lol)(+ 1 2)\n\n( \n ( 2 3))"
+                   :text/range [[3 3] [3 7]]}
+                  [{:text/block [:text/contents :text/range]}
+                   {:text/ns [:text/contents :text/range]}
+                   {:text/top-block [:text/contents :text/range]}
+                   {:text/current-var [:text/contents :text/range]}
+                   {:text/selection [:text/contents :text/range]}])
+             => {:text/block {:text/range [[3 1] [3 6]]
+                              :text/contents "( 2 3)"}
+                 :text/top-block {:text/contents "( \n ( 2 3))"
+                                  :text/range [[2 0] [3 7]]}
+                 :text/current-var {:text/range [[3 3] [3 3]]
+                                    :text/contents "2"}
+                 :text/selection {:text/range [[3 3] [3 7]]
+                                  :text/contents "2 3))"}
+                 :text/ns {:text/contents "lol"
+                           :text/range [[0 0] [0 7]]}}))
 
+    (testing "gets block/selection/etc from text editor"
+      (check (eql {:editor/data {:contents "(ns lol)(+ 1 2)\n\n( \n ( 2 3))"
+                                 :filename nil
+                                 :range [[3 3] [3 7]]}}
+                  [{:text/block [:text/contents :text/range]}
+                   {:text/ns [:text/contents :text/range]}
+                   {:text/top-block [:text/contents :text/range]}
+                   {:text/current-var [:text/contents :text/range]}
+                   {:text/selection [:text/contents :text/range]}])
+             => {:text/block {:text/range [[3 1] [3 6]]
+                              :text/contents "( 2 3)"}
+                 :text/top-block {:text/contents "( \n ( 2 3))"
+                                  :text/range [[2 0] [3 7]]}
+                 :text/current-var {:text/range [[3 3] [3 3]]
+                                    :text/contents "2"}
+                 :text/selection {:text/range [[3 3] [3 7]]
+                                  :text/contents "2 3))"}
+                 :text/ns {:text/contents "lol"
+                           :text/range [[0 0] [0 7]]}}))
 
-    (testing "gets current block"
-      (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-                                 :filename "foo.clj"
-                                 :range [[3 4] [3 7]]}}
-                  [{:editor/block [:text/contents :text/range]}])
-             => {:editor/block {:text/range [[3 1] [3 6]]
-                                :text/contents "( 2 3)"}}))
-
-    (testing "gets current selection"
-      (check (eql {:editor/data {:contents "(+ 1 2)\n\n( \n ( 2 3))"
-                                 :filename "foo.clj"
-                                 :range [[2 0] [3 6]]}}
-                  [{:editor/selection [:text/contents :text/range]}])
-             => {:editor/selection {:text/range [[2 0] [3 6]]
-                                    :text/contents "( \n ( 2 3)"}}))))
+    (testing "keep reference of the current namespace for each element"
+      (check (eql {:editor/data {:contents "(ns lol)(+ 1 2)\n\n( \n ( 2 3))"
+                                 :filename nil
+                                 :range [[3 3] [3 7]]}}
+                  [{:text/block [:text/ns]}
+                   {:text/top-block [:text/ns]}
+                   {:text/current-var [:text/ns]}
+                   {:text/selection [:text/ns]}])
+             => {:text/block {:text/ns {:text/contents "lol"
+                                        :text/range [[0 0] [0 7]]}}
+                 :text/top-block {:text/ns {:text/contents "lol"
+                                              :text/range [[0 0] [0 7]]}}
+                 :text/current-var {:text/ns {:text/contents "lol"
+                                              :text/range [[0 0] [0 7]]}}
+                 :text/selection {:text/ns {:text/contents "lol"
+                                            :text/range [[0 0] [0 7]]}}}))))
 
 (deftest config-for-repl
   (async-test "separates editor data into fragments" {:timeout 8000}
@@ -109,26 +169,29 @@
 
 (deftest ns-from-contents
   (async-test "separates editor data into fragments" {:timeout 8000}
-    (let [seed {:editor/contents "\n(ns first.namespace)\n\n(+ 1 2)\n\n(ns second.ns)\n\n(+ 3 4)"}]
+    (let [seed {:editor/text
+                {:text/contents
+                 "\n(ns first.namespace)\n\n(+ 1 2)\n\n(ns second.ns)\n\n(+ 3 4)"}}]
+      (p/do!)
       (testing "gets namespace if declaration is below current selection"
-        (check (eql (assoc seed :editor/range [[0 0] [0 0]])
-                    [{:editor/ns [:text/range :text/contents]}])
-               => {:editor/ns {:text/range [[1 0] [1 19]]
-                               :text/contents "first.namespace"}}))
+        (check (eql (assoc-in seed [:editor/text :text/range] [[0 0] [0 0]])
+                    [:text/ns])
+               => {:text/ns {:text/range [[1 0] [1 19]]
+                                       :text/contents "first.namespace"}}))
 
       (testing "gets namespace if declaration is above current selection"
-        (check (eql (assoc seed :editor/range [[2 0] [2 0]])
-                    [{:editor/ns [:text/range :text/contents]}])
-               => {:editor/ns {:text/range [[1 0] [1 19]]
-                               :text/contents "first.namespace"}})
+        (check (eql (assoc-in seed [:editor/text :text/range] [[2 0] [2 0]])
+                    [:text/ns])
+               => {:text/ns {:text/range [[1 0] [1 19]]
+                             :text/contents "first.namespace"}})
 
-        (check (eql (assoc seed :editor/range [[5 0] [5 0]])
-                    [{:editor/ns [:text/range :text/contents]}])
-               => {:editor/ns {:text/range [[5 0] [5 13]]
-                               :text/contents "second.ns"}}))
+        (check (eql (assoc-in seed [:editor/text :text/range]  [[5 0] [5 0]])
+                    [:text/ns])
+               => {:text/ns {:text/range [[5 0] [5 13]]
+                             :text/contents "second.ns"}}))
 
       (testing "gets REPL namespace if a ns exists"
-        (check (eql (assoc seed :editor/range [[2 0] [2 0]])
+        (check (eql (assoc-in seed [:editor/text :text/range]  [[2 0] [2 0]])
                     [:repl/namespace])
                => {:repl/namespace 'first.namespace}))
 
@@ -142,7 +205,3 @@
                      :repl/kind :cljs}
                     [:repl/namespace])
                => {:repl/namespace 'cljs.user})))))
-
-#?(:cljs
-   (defn- ^:dev/after-load run []
-     (run-tests)))

--- a/test/duck_repled/editor_test.cljc
+++ b/test/duck_repled/editor_test.cljc
@@ -205,3 +205,15 @@
                      :repl/kind :cljs}
                     [:repl/namespace])
                => {:repl/namespace 'cljs.user})))))
+
+(deftest read-file-contents
+  (async-test "read file contents and extract fragments"
+    (check (eql {:file/filename "test/duck_repled/tests.cljs"}
+                [{:file/contents [:text/ns]}])
+           => {:file/contents {:text/ns {:text/contents "duck-repled.tests"}}})
+
+    (check (eql {:file/filename "test/duck_repled/tests.cljs"}
+                [{'(:file/contents {:range [[10 0] [10 0]]}) [:text/contents :text/top-block]}])
+           => {:file/contents {:text/top-block
+                               {:text/contents #"^.defmethod test/report"
+                                :text/range [[10 0] [11 48]]}}})))

--- a/test/duck_repled/tests.cljs
+++ b/test/duck_repled/tests.cljs
@@ -23,6 +23,9 @@
                                      (js/parseInt port)))
     (set! helpers/*cljs-evaluator* nil)))
 
+(defn- ^:dev/after-load run-tests []
+  (test/run-all-tests #"duck-repled.*-test"))
+
 (defn main [ & args]
   ; (when (->> args first (re-matches #"\d+"))
   ;   (p/let [repl (helpers/connect-node-repl! "localhost" (js/parseInt (first args)))]
@@ -36,7 +39,7 @@
         (js/process.exit 0)
         (js/process.exit 1)))
     (when (-> args count (= 1))
-      (test/run-all-tests #"duck-repled.*-test")))
+      (run-tests)))
 
   (when (-> args count (>= 2))
     (connect-socket! (rest args))
@@ -48,8 +51,8 @@
            (do
              (println "CLJS REPL didn't connect in 2m")
              (js/process.exit 2))
-           (test/run-all-tests #"duck-repled.*-test")))
-       (test/run-all-tests #"duck-repled.*-test"))))
+           (run-tests)))
+       (run-tests))))
 
   (when (= [] args)
     (prn :loaded)))


### PR DESCRIPTION
Changed the way resolvers work. Instead of depending on `editor/*`, it now depends on `:contents/*`.

This makes it easier to get info like "top blocks from the contents of a file", or "top blocks from the contents of a JAR file"